### PR TITLE
Version of Easymore to be read from package's data

### DIFF
--- a/easymore/__init__.py
+++ b/easymore/__init__.py
@@ -1,1 +1,18 @@
+"""
+Easymore's global module
+"""
+
+# version handling
+try:
+    from importlib.metadata import version as _version
+except ImportError:
+    # if the fallback library is missing, we are doomed.
+    from importlib_metadata import version as _version
+try:
+    __version__ = _version("easymore")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
+
 from easymore.easymore import easymore

--- a/easymore/easymore.py
+++ b/easymore/easymore.py
@@ -13,6 +13,7 @@ from   datetime     import datetime
 import re
 import json
 
+from easymore import __version__
 
 class easymore:
 
@@ -60,8 +61,8 @@ class easymore:
         self.save_csv                  =  False # save csv
         self.sort_ID                   =  False # to sort the remapped based on the target shapfile ID; self.target_shp_ID should be given
         self.complevel                 =  4 # netcdf compression level from 1 to 9. Any other value or object will mean no compression.
-        self.version                   =  '1.1.0' # version of the easymore
-        print('EASYMORE version '+self.version+ ' is initiated.')
+
+        print(f'EASYMORE version {__version__} is initiated.')
 
 
     ##############################################################


### PR DESCRIPTION
Using `importlib_metadata`, the version is now read from the package's data after installation with `setuptools`. This was mainly due to preventing inconsistencies that may arise by using `self.version` that is implemented in the main `easymore` class of this package.

Reported-by: Kasra Keshavarz <kasra.keshavarz1@ucalgary.ca>