### PR TITLE
remapped-variable was not translated properly

### DIFF
--- a/src/easymore/scripts/main.py
+++ b/src/easymore/scripts/main.py
@@ -71,11 +71,16 @@ def from_cli(**kwargs):
     job_conf = 'submit_job_conf'  # SLURM job submission file
     job_deps = 'dependency'  # for SLURM dependencies given
     var = 'var_names'  # list of variables
+    var_remapped = 'var_names_remapped'
     cache = 'temp_dir'  # temporary directory
 
     # if list of variables is given as a comma-separated values
     if ',' in kwargs[var][0]:
         kwargs[var] = kwargs[var][0].split(',')
+
+    # if list of remapped variables is given as a comma-separated values
+    if ',' in kwargs[var_remapped][0]:
+        kwargs[var_remapped] = kwargs[var_remapped][0].split(',')
 
     # creating parameter dictionary for Easymore
     esmr_kwargs = {k: v for k, v in kwargs.items() if k not in

--- a/src/easymore/scripts/main.py
+++ b/src/easymore/scripts/main.py
@@ -79,8 +79,9 @@ def from_cli(**kwargs):
         kwargs[var] = kwargs[var][0].split(',')
 
     # if list of remapped variables is given as a comma-separated values
-    if ',' in kwargs[var_remapped][0]:
-        kwargs[var_remapped] = kwargs[var_remapped][0].split(',')
+    if var_remapped in kwargs:
+        if ',' in kwargs[var_remapped][0]:
+            kwargs[var_remapped] = kwargs[var_remapped][0].split(',')
 
     # creating parameter dictionary for Easymore
     esmr_kwargs = {k: v for k, v in kwargs.items() if k not in


### PR DESCRIPTION
Basically the title.

The `remapped-variable` CLI argument was not being translated properly. This commit takes care of it. 

Reported-by: Hongli Liu <hongli7@ualberta.ca>