### PR TITLE
Error handling with empty `var_names_remapped` CLI argument

### DIFF
--- a/src/easymore/scripts/main.py
+++ b/src/easymore/scripts/main.py
@@ -80,8 +80,9 @@ def from_cli(**kwargs):
 
     # if list of remapped variables is given as a comma-separated values
     if var_remapped in kwargs:
-        if ',' in kwargs[var_remapped][0]:
-            kwargs[var_remapped] = kwargs[var_remapped][0].split(',')
+        if kwargs[var_remapped]:
+            if ',' in kwargs[var_remapped][0]:
+                kwargs[var_remapped] = kwargs[var_remapped][0].split(',')
 
     # creating parameter dictionary for Easymore
     esmr_kwargs = {k: v for k, v in kwargs.items() if k not in


### PR DESCRIPTION
This PR assures further checks are implement on this variable, only if it is provided.